### PR TITLE
Ensure grunt fails when tests fail

### DIFF
--- a/tasks/testling.js
+++ b/tasks/testling.js
@@ -8,7 +8,11 @@ module.exports = function (grunt) {
     var local = path.join(process.cwd(), 'node_modules/testling/bin/cmd.js');
     var isLocal = fs.existsSync(local);
     var opts = { stdio: 'inherit' };
+    var process;
 
-    spawn(isLocal ? local : 'testling', [], opts).on('exit', done);
+    process = spawn(isLocal ? local : 'testling', [], opts);
+    process.on('close', function(code) {
+      done(!code);
+    });
   });
 };


### PR DESCRIPTION
The previous code was just calling grunt async done when the tests
failed. It needs to pass a boolean for whether the task actually failed
or not.

The code returned will be 0 if successful and a number (usually 1) if
not. So we pass the inverse of this to fail or pass the task.
